### PR TITLE
docs(dev): remove useless global install of deprecated `expo-cli`

### DIFF
--- a/docs/development/app/android.md
+++ b/docs/development/app/android.md
@@ -38,12 +38,6 @@ Une fois le repo cloné, installez simplement les packages npm liés :
 npm i
 ```
 
-Il sera aussi nécessaire d'avoir [**Expo CLI**](https://docs.expo.dev/more/expo-cli/){target=_blank} :
-
-```
-npm install -g expo-cli
-```
-
 ## **Développement**
 
 Pour lancer l'application en mode développement, vous devez installer l'application de développement (un mini Expo Go qui permet de charger l'application depuis votre PC avec un live reload)

--- a/docs/development/app/eas.md
+++ b/docs/development/app/eas.md
@@ -36,10 +36,10 @@ Une fois le repo cloné, installez simplement les packages npm liés :
 npm i
 ```
 
-Il sera aussi nécessaire d'avoir [**Expo CLI**](https://docs.expo.dev/more/expo-cli/){target=\_blank} ainsi que [**EAS CLI**](https://docs.expo.dev/build/setup/){target=\_blank} :
+Il sera aussi nécessaire d'avoir [**EAS CLI**](https://docs.expo.dev/build/setup/){target=\_blank} :
 
 ```
-npm install -g expo-cli eas-cli
+npm install -g eas-cli
 ```
 
 ## **Développement**

--- a/docs/development/app/ios.md
+++ b/docs/development/app/ios.md
@@ -47,12 +47,6 @@
     npm i
     ```
 
-    Il sera aussi nécessaire d'avoir [**Expo CLI**](https://docs.expo.dev/more/expo-cli/) :
-
-    ```
-    npm install -g expo-cli
-    ```
-
     Vous devrez aussi installer les dépendances de [**Cocoapods**](https://cocoapods.org/) dans le dossier *`/ios`*:
 
     ```


### PR DESCRIPTION
The `expo-cli` module is deprecated since the beginning of this year, as the GitHub repo is archived since Jan 18, 2024. We don't need to install it as a global module anymore, as the "CLI" module is already included into expo. Thus, it shouldn't be advised to install this outdated and useless module in the docs as of now.